### PR TITLE
chore: pin stylelint version and regen lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,148 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.3.tgz",
+      "integrity": "sha512-vH+ONMtvkQpjvKAXl5shNFyIpBwmkgKjo+buySLpQsMNDlqbJcFIMiYhwDrK4isZsae+QeHJYbqUJ0BYwyKNZw==",
+      "requires": {
+        "@babel/highlight": "7.0.0-rc.3"
+      }
+    },
+    "@babel/core": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.3.tgz",
+      "integrity": "sha512-fcV6YSIMqAVOyclCYltNtcn4bboBO1qppam6K65wfAne7phQN9h0DrehySalO+Z4XNbx+lhcO/W1JghkjaG3iA==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-rc.3",
+        "@babel/generator": "7.0.0-rc.3",
+        "@babel/helpers": "7.0.0-rc.3",
+        "@babel/parser": "7.0.0-rc.3",
+        "@babel/template": "7.0.0-rc.3",
+        "@babel/traverse": "7.0.0-rc.3",
+        "@babel/types": "7.0.0-rc.3",
+        "convert-source-map": "^1.1.0",
+        "debug": "^3.1.0",
+        "json5": "^0.5.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.3.tgz",
+      "integrity": "sha512-vTpLY/3fV5ML2DxvrvU1/n6cV9+yEj9Do9zrb8UopKSa5WVyjo4tzH0Gp9Ka7zThn5kp4XB3DH385eHOVbwN9g==",
+      "requires": {
+        "@babel/types": "7.0.0-rc.3",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.3.tgz",
+      "integrity": "sha512-tSftL9o8SiOS0xF/6EQUKmEjWkSR3mN/inN5fOD8rrD/Yb+gVDfFrKQDJEfkKwEU2IRKEO7MF23WoEdgE1ggAg==",
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-rc.3",
+        "@babel/template": "7.0.0-rc.3",
+        "@babel/types": "7.0.0-rc.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.3.tgz",
+      "integrity": "sha512-zzOTCRPQKmYX7FNDjys7DNdMx330QCXcbr54PV28RmBuHdCDeYue/5OVm7OcRvekvULPTJ+CT3tvDMhprt4A/Q==",
+      "requires": {
+        "@babel/types": "7.0.0-rc.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.3.tgz",
+      "integrity": "sha512-DX5GgUSuNwoc1MelrVh8CkZtCF29LoNmvwG+9AMWW8n9WXMDQUtoAWivgJ0VkE6DYtIO0CaXmma9Odsuc4+t5Q==",
+      "requires": {
+        "@babel/types": "7.0.0-rc.3"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.3.tgz",
+      "integrity": "sha512-09V1JpMyRB03CXmW4qBicCOu89xO4U+f5aNqojUfonFmo4mRCL2ZRt6UgjxgkE2usD1krbgBIAk1uwSOUFebbA==",
+      "requires": {
+        "@babel/template": "7.0.0-rc.3",
+        "@babel/traverse": "7.0.0-rc.3",
+        "@babel/types": "7.0.0-rc.3"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.3.tgz",
+      "integrity": "sha512-BwDi54dopTDbp0nIXZ1Ln7dGaZx8Vxqi8IKVFxtHHFhlTMxwVnYZlRFamRy7yOG4KEemRYhENq5ea/cNa9Jvjw==",
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.3.tgz",
+      "integrity": "sha512-oNVEL3NpMaC8q1hQwWrmgj34dAT3KIAK5zhVN4V6YTzotJOSK0ul7SaRm42YDdP56aOkzvGAZylCVtvu6jREhg=="
+    },
+    "@babel/template": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.3.tgz",
+      "integrity": "sha512-UaP8IpJkOuo4w7dUl7Wn/zvW3HTp+OHWX2Rve3xF/TnzFni06hOUEzb5XOZqvAkMNbchPA179OUQuXsobnPB6Q==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-rc.3",
+        "@babel/parser": "7.0.0-rc.3",
+        "@babel/types": "7.0.0-rc.3"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.3.tgz",
+      "integrity": "sha512-6f7ge8Yz1WjL5wbFaFYZR0fN1BOFOLAHe7PxkKqr9sFcPP/dLE1DqVi540CONk7yhwwpoPspDcnqNLDqTZDQRg==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-rc.3",
+        "@babel/generator": "7.0.0-rc.3",
+        "@babel/helper-function-name": "7.0.0-rc.3",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.3",
+        "@babel/parser": "7.0.0-rc.3",
+        "@babel/types": "7.0.0-rc.3",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.3.tgz",
+      "integrity": "sha512-9sN1GWRztypQ2lViYR9HcClQILkObaX8vNFwrdgtMGB697xQePxSZqyhe8R2VR0afnJ1Jdg7y4X+IRE2CDRhDQ==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@gimenete/type-writer": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@gimenete/type-writer/-/type-writer-0.1.3.tgz",
@@ -99,16 +241,16 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.0.4.tgz",
-      "integrity": "sha512-ExGXP9GnM2hqUIgTnp6sXKB1G0Yh+fuLftmIopq5KHBWj34Wd2YbM/3iLkXXnAP1YZ9YCp7hsAdsR014ctbwHg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.0.2.tgz",
+      "integrity": "sha512-h0tNQGGd4pXO9AUVa3LlVLafMF2CJU7TRwl0KTqWLfmb5sFOxNRK4yIkoD/TCmMUst4vxgG57H1fPaD7GE17Fg==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
         "aggregate-error": "^1.0.0",
         "detect-indent": "^5.0.0",
         "detect-newline": "^2.1.0",
-        "execa": "^1.0.0",
+        "execa": "^0.10.0",
         "fs-extra": "^7.0.0",
         "lodash": "^4.17.4",
         "nerf-dart": "^1.0.0",
@@ -120,6 +262,33 @@
         "registry-auth-token": "^3.3.1"
       },
       "dependencies": {
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
         "read-pkg": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
@@ -181,14 +350,14 @@
       }
     },
     "ajv": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+      "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.1"
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-keywords": {
@@ -328,15 +497,15 @@
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "autoprefixer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.0.2.tgz",
-      "integrity": "sha512-t5PpCq5nCNzgPEzhty83UHYLmteY9FTL3COBfRjL0y4BTDB0OADbHVzG/S7gzqvITSsAZiaJPduoDEv2n68JNQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.0.0.tgz",
+      "integrity": "sha512-bMt9puCb+xk5ds1ghr1zzfJ09+SjOcseHCEawhMjibM5KfxkodW8PQMhhEnllyj4Cz3Yixy9A+/0De2VC9R+dQ==",
       "requires": {
         "browserslist": "^4.0.1",
         "caniuse-lite": "^1.0.30000865",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.2",
+        "postcss": "^7.0.0",
         "postcss-value-parser": "^3.2.3"
       }
     },
@@ -658,17 +827,17 @@
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "colors": {
       "version": "1.0.3",
@@ -810,6 +979,11 @@
         }
       }
     },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -821,9 +995,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
-      "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+      "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
       "requires": {
         "is-directory": "^0.3.1",
         "js-yaml": "^3.9.0",
@@ -1069,13 +1243,30 @@
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "env-ci": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-2.1.3.tgz",
-      "integrity": "sha512-8bK5aK5Lj9i82JM4tKAIOTxqHI+N6dSBqb9fFkB1oi26Pe6f3upwA88OLxsNzzc+dDm9l4qU5lmJMqszghT/Ag==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-2.1.2.tgz",
+      "integrity": "sha512-Ovu150QuyPbK8q8LRRaCQILDp91NSABrHfhAlJY4JwoC0eYJlQ+FlGs5YWtN395/Pcmno9IH+Y3pxN9865veYQ==",
       "dev": true,
       "requires": {
-        "execa": "^1.0.0",
+        "execa": "^0.11.0",
         "java-properties": "^0.2.9"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.11.0.tgz",
+          "integrity": "sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "error-ex": {
@@ -1110,6 +1301,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "execa": {
       "version": "1.0.0",
@@ -1606,6 +1802,11 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
+    "globals": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+    },
     "globby": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
@@ -1624,6 +1825,11 @@
           "version": "3.3.10",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
           "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -1767,9 +1973,9 @@
       }
     },
     "ignore": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.3.tgz",
-      "integrity": "sha512-Z/vAH2GGIEATQnBVXMclE2IGV6i0GyVngKThcGZ5kHgHMxLo9Ow2+XHRq1aEKEej5vOF1TPJNbvX6J/anT0M7A=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.2.tgz",
+      "integrity": "sha512-uoxnT7PYpyEnsja+yX+7v49B7LXxmzDJ2JALqHH3oEGzpM2U1IGcbfnOr8Dt57z3B/UWs7/iAgPFbmye8m4I0g=="
     },
     "import-from": {
       "version": "2.1.0",
@@ -2146,6 +2352,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz",
       "integrity": "sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q=="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
     "js-yaml": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
@@ -2154,6 +2365,11 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2170,6 +2386,11 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -2221,6 +2442,13 @@
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "locate-path": {
@@ -2346,9 +2574,9 @@
       "dev": true
     },
     "marked-terminal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.1.1.tgz",
-      "integrity": "sha512-7UBFww1rdx0w9HehLMCVYa8/AxXaiDigDfMsJcj82/wgLQG9cj+oiMAVlJpeWD57VFJY2OYY+bKeEVIjIlxi+w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.1.0.tgz",
+      "integrity": "sha512-PSfCnhQCVO7T4Q9JHgvjcv//orjaunCO5IZXR2/RgDgJFhU3yzDwbCgi09RzEfe5UrsGzLM3rkfiKP3aCFBJ1A==",
       "dev": true,
       "requires": {
         "cardinal": "^2.1.1",
@@ -2586,9 +2814,9 @@
       "dev": true
     },
     "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
     },
     "node-emoji": {
@@ -2607,9 +2835,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
+      "version": "1.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+      "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -2650,9 +2878,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.0.tgz",
-      "integrity": "sha512-k0VteQaxRuI1mREBxCtLUksesD2ZmX5gxjXNEjTmTrxQ3SHW22InkCKyX4NzoeGAYtgmDg5MuE7rcXYod7xgug==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.3.0.tgz",
+      "integrity": "sha512-oDtLFo3wXue/xe3pU/oks9VHS5501OAWlYrZrApZkFv7l2LXk+9CfPMbjbfZWK7Jqlc1jbNcJMkB6KZC7K/vEA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.3",
@@ -2685,8 +2913,8 @@
         "glob": "~7.1.2",
         "graceful-fs": "~4.1.11",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
-        "iferr": "^1.0.2",
+        "hosted-git-info": "^2.6.0",
+        "iferr": "^1.0.0",
         "imurmurhash": "*",
         "inflight": "~1.0.6",
         "inherits": "~2.0.3",
@@ -2695,7 +2923,7 @@
         "is-cidr": "^2.0.6",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.1",
+        "libcipm": "^2.0.0",
         "libnpmhook": "^4.0.1",
         "libnpx": "^10.2.0",
         "lock-verify": "^2.0.2",
@@ -2716,7 +2944,7 @@
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.8.0",
+        "node-gyp": "^3.7.0",
         "nopt": "~4.0.1",
         "normalize-package-data": "~2.4.0",
         "npm-audit-report": "^1.3.1",
@@ -2747,7 +2975,7 @@
         "read-package-tree": "^5.2.1",
         "readable-stream": "^2.3.6",
         "readdir-scoped-modules": "*",
-        "request": "^2.87.0",
+        "request": "^2.81.0",
         "retry": "^0.12.0",
         "rimraf": "~2.6.2",
         "safe-buffer": "^5.1.2",
@@ -2758,7 +2986,7 @@
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.0",
         "stringify-package": "^1.0.0",
-        "tar": "^4.4.6",
+        "tar": "^4.4.4",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -2767,7 +2995,7 @@
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
         "uuid": "^3.3.2",
-        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-license": "^3.0.3",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
         "worker-farm": "^1.6.0",
@@ -2802,17 +3030,6 @@
           "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
           }
         },
         "ansi-align": {
@@ -2876,7 +3093,7 @@
           "dev": true
         },
         "assert-plus": {
-          "version": "1.0.0",
+          "version": "0.2.0",
           "bundled": true,
           "dev": true
         },
@@ -2886,7 +3103,7 @@
           "dev": true
         },
         "aws-sign2": {
-          "version": "0.7.0",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true
         },
@@ -2933,6 +3150,14 @@
           "version": "3.5.1",
           "bundled": true,
           "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
         },
         "boxen": {
           "version": "1.3.0",
@@ -3138,7 +3363,7 @@
           "dev": true
         },
         "colors": {
-          "version": "1.1.2",
+          "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3244,6 +3469,14 @@
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.x.x"
           }
         },
         "crypto-random-string": {
@@ -3457,16 +3690,6 @@
           "bundled": true,
           "dev": true
         },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "figgy-pudding": {
           "version": "3.2.0",
           "bundled": true,
@@ -3500,12 +3723,12 @@
           "dev": true
         },
         "form-data": {
-          "version": "2.3.2",
+          "version": "2.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
+            "combined-stream": "^1.0.5",
             "mime-types": "^2.1.12"
           }
         },
@@ -3694,17 +3917,28 @@
           "dev": true
         },
         "har-schema": {
-          "version": "2.0.0",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true
         },
         "har-validator": {
-          "version": "5.0.3",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
+              }
+            }
           }
         },
         "has-flag": {
@@ -3717,8 +3951,24 @@
           "bundled": true,
           "dev": true
         },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
         "hosted-git-info": {
-          "version": "2.7.1",
+          "version": "2.6.0",
           "bundled": true,
           "dev": true
         },
@@ -3737,11 +3987,11 @@
           }
         },
         "http-signature": {
-          "version": "1.2.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "^0.2.0",
             "jsprim": "^1.2.2",
             "sshpk": "^1.7.0"
           }
@@ -3772,7 +4022,7 @@
           }
         },
         "iferr": {
-          "version": "1.0.2",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -3953,13 +4203,21 @@
           "bundled": true,
           "dev": true
         },
-        "json-schema-traverse": {
-          "version": "0.3.1",
+        "json-stable-stringify": {
+          "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
           "bundled": true,
           "dev": true
         },
@@ -4008,7 +4266,7 @@
           }
         },
         "libcipm": {
-          "version": "2.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4017,7 +4275,6 @@
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
             "lock-verify": "^2.0.2",
-            "mkdirp": "^0.5.1",
             "npm-lifecycle": "^2.0.3",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
@@ -4331,7 +4588,7 @@
           }
         },
         "node-gyp": {
-          "version": "3.8.0",
+          "version": "3.7.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4342,7 +4599,7 @@
             "nopt": "2 || 3",
             "npmlog": "0 || 1 || 2 || 3 || 4",
             "osenv": "0",
-            "request": "^2.87.0",
+            "request": ">=2.9.0 <2.82.0",
             "rimraf": "2",
             "semver": "~5.3.0",
             "tar": "^2.0.0",
@@ -4811,7 +5068,7 @@
           "dev": true
         },
         "performance-now": {
-          "version": "2.1.0",
+          "version": "0.2.0",
           "bundled": true,
           "dev": true
         },
@@ -4923,7 +5180,7 @@
           "dev": true
         },
         "qs": {
-          "version": "6.5.2",
+          "version": "6.4.0",
           "bundled": true,
           "dev": true
         },
@@ -5056,30 +5313,32 @@
           }
         },
         "request": {
-          "version": "2.87.0",
+          "version": "2.81.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
             "caseless": "~0.12.0",
             "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
+            "extend": "~3.0.0",
             "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
             "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
             "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "uuid": "^3.0.0"
           }
         },
         "require-directory": {
@@ -5187,6 +5446,14 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
         },
         "socks": {
           "version": "2.2.0",
@@ -5378,6 +5645,11 @@
           "bundled": true,
           "dev": true
         },
+        "stringstream": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
@@ -5405,7 +5677,7 @@
           }
         },
         "tar": {
-          "version": "4.4.6",
+          "version": "4.4.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5574,7 +5846,7 @@
           "dev": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.4",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6055,18 +6327,30 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
         "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.0.tgz",
+      "integrity": "sha512-zrSP/KDf9DH3K3VePONoCstgPiYJy9z0SCatZuTpOc7YdnWIqwkWdXOuwlr4uDc7em8QZRsFWsT/685x5InjYg=="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -6107,11 +6391,20 @@
       }
     },
     "postcss-html": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.31.0.tgz",
-      "integrity": "sha512-5orIml7dVf17OrHyO39BXMGlklKT884FvkB+gdCtGJ63b1AAeGF7NuXGC1HM83TI0Ip1gZyBowrPuXCOPqqerA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.33.0.tgz",
+      "integrity": "sha512-3keDoRG0o8bJZKe/QzkOPUD3GQQvAmYhIAtsGrgTxIXB6xZnSQq3gwPjCEd2IAUtz9/Fkus70XGm6xJEZ+bAmg==",
       "requires": {
         "htmlparser2": "^3.9.2"
+      }
+    },
+    "postcss-jsx": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.33.0.tgz",
+      "integrity": "sha512-+ZH4FyxQel2O5uYkNKBnDdW2jCwIb5HwwyFsKuEI164Vmq9Wm07nT2lj65P1qDSRXP2Ik05DrSHzY8Hmt5VP4A==",
+      "requires": {
+        "@babel/core": "^7.0.0-rc.1",
+        "postcss-styled": ">=0.33.0"
       }
     },
     "postcss-less": {
@@ -6178,9 +6471,9 @@
       }
     },
     "postcss-markdown": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.31.0.tgz",
-      "integrity": "sha512-2fKbCxnyACX0ZSRpgZD0XYmVLlz0Sam8cCy423xn08t/EygOYPsK6FOp7gGrLsVXzQVwtN3HNLfcPkiseIZSSA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.33.0.tgz",
+      "integrity": "sha512-JZtetO15t5nNpymHDbRhuiOF8yJm1btrbUBP3iL39yLTiY8oChCsnCKfQjEuHB9+85fku5MoU/bRgQ8K45klMg==",
       "requires": {
         "remark": "^9.0.0",
         "unist-util-find-all-after": "^1.0.2"
@@ -6257,11 +6550,11 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-4.0.0.tgz",
-      "integrity": "sha512-5h+MvEjnzu1qy6MabjuoPatsGAjjDV9B24e7Cktjl+ClNtjVjmvAXjOFQr1u7RlWULKNGYaYVE4s+DIIQ4bOGA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
       "requires": {
-        "cssesc": "^1.0.1",
+        "dot-prop": "^4.1.1",
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
       }
@@ -6276,14 +6569,14 @@
       }
     },
     "postcss-styled": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.31.0.tgz",
-      "integrity": "sha512-tyCeU0XuuJJdmLmnklWuvcQe8zFIRoq+zof2K19UqdvoH8+P007vu9ShSRcu7S/LcjB+VWJl1tyqUszgFIjcDQ=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.33.0.tgz",
+      "integrity": "sha512-ybKIBKYY6q0hADQUECW2F4fDybDFIiAfpMf06/2maxU0yp0FvMTeABrDjzSmKu+99Nj2Gsxe80Xn56FbhzIZZQ=="
     },
     "postcss-syntax": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.31.0.tgz",
-      "integrity": "sha512-siI3tp74W8paHBCfEEeSCta5GUnEEEztAbkyL87/tqwW6wl2o4CbRA6utW30n9gz/FEqe+eOhvVPXpbpqmcdWw=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.33.0.tgz",
+      "integrity": "sha512-A9ABlaRy7KWUfG5E39GVTUoc5TXNuNTts5GzwDLwnSaVG151CSLCTcr51/m8cHi4KXcYa+5ImLyeSfBOhEYtGw=="
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -6543,6 +6836,14 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -7083,9 +7384,9 @@
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.4.0.tgz",
-      "integrity": "sha512-pcw0Dpb4Ib/OfgONhaeF+myA+5iZdsI8dYgWs1++IYN/dgvo90O0FhgMDKb1bMgZVy/A2Q1CCN/PFZ0FLnnRnQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.5.0.tgz",
+      "integrity": "sha512-63R/DGDjMekFwS4xaHSLy26N19pT1Jsxj7u5QNcJrUWBvvPoBCYx3ObINRgsvNMoupzhV7N0PjylxrDHyh4cKQ==",
       "requires": {
         "autoprefixer": "^9.0.0",
         "balanced-match": "^1.0.0",
@@ -7108,11 +7409,12 @@
         "meow": "^5.0.0",
         "micromatch": "^2.3.11",
         "normalize-selector": "^0.2.0",
-        "pify": "^3.0.0",
+        "pify": "^4.0.0",
         "postcss": "^7.0.0",
-        "postcss-html": "^0.31.0",
+        "postcss-html": "^0.33.0",
+        "postcss-jsx": "^0.33.0",
         "postcss-less": "^2.0.0",
-        "postcss-markdown": "^0.31.0",
+        "postcss-markdown": "^0.33.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-reporter": "^5.0.0",
         "postcss-resolve-nested-selector": "^0.1.1",
@@ -7120,29 +7422,17 @@
         "postcss-sass": "^0.3.0",
         "postcss-scss": "^2.0.0",
         "postcss-selector-parser": "^3.1.0",
-        "postcss-styled": "^0.31.0",
-        "postcss-syntax": "^0.31.0",
+        "postcss-styled": "^0.33.0",
+        "postcss-syntax": "^0.33.0",
         "postcss-value-parser": "^3.3.0",
         "resolve-from": "^4.0.0",
         "signal-exit": "^3.0.2",
         "specificity": "^0.4.0",
         "string-width": "^2.1.0",
         "style-search": "^0.1.0",
-        "sugarss": "^1.0.0",
+        "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
         "table": "^4.0.1"
-      },
-      "dependencies": {
-        "postcss-selector-parser": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
-          "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        }
       }
     },
     "stylelint-config-recommended": {
@@ -7186,26 +7476,26 @@
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^4.0.0",
         "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-4.0.0.tgz",
+          "integrity": "sha512-5h+MvEjnzu1qy6MabjuoPatsGAjjDV9B24e7Cktjl+ClNtjVjmvAXjOFQr1u7RlWULKNGYaYVE4s+DIIQ4bOGA==",
+          "requires": {
+            "cssesc": "^1.0.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "sugarss": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
-      "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+      "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
       "requires": {
-        "postcss": "^6.0.14"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        }
+        "postcss": "^7.0.2"
       }
     },
     "supports-color": {
@@ -7255,6 +7545,11 @@
         "readable-stream": "^2.1.5",
         "xtend": "~4.0.1"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -7315,6 +7610,11 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trim-trailing-lines": {
       "version": "1.1.1",
@@ -7468,19 +7768,11 @@
       "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
     },
     "unist-util-visit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
+      "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "unist-util-visit-parents": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
-      "requires": {
-        "unist-util-is": "^2.1.2"
+        "unist-util-is": "^2.1.1"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "stylelint-scss": "3.3.0"
   },
   "peerDependencies": {
-    "stylelint": "^9.1.0"
+    "stylelint": "9.5.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
[PR Process](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-process) - [PR Review Checklist](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-review-checklist)

### Release

Semantic release is enabled for this repository. Make sure you follow the right commit message convention. 

We're using semantic-release's default — [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).

## Description of Changes

Attempts to fix a problem with the 'npm ci' command in travis reporting that the package.json and package-lock.json are out of sync on greenkeeper PRs. It may be that we can no longer pin sub-dependencies like we had been doing in node 9 as demonstrated by all the '^' in the version string in package-lock.json now.
